### PR TITLE
Tried to solve the issue #204 : Basemapper allow for in memory BytesIO GeoJSON f…

### DIFF
--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -19,6 +19,7 @@
 #
 """Module for generating basemaps from various providers."""
 
+import json
 import argparse
 import concurrent.futures
 import logging
@@ -26,8 +27,10 @@ import queue
 import re
 import sys
 import threading
+from shapely.ops import unary_union  # Used to handle cases where multiple geometries are provided
+from shapely.geometry import shape, MultiPolygon, Polygon  # Used to model and manipulate geometric shapes like Polygon
 from pathlib import Path
-from typing import Union
+from typing import Union, Tuple
 
 import geojson
 import mercantile
@@ -49,6 +52,9 @@ from shapely.ops import unary_union
 from osm_fieldwork.sqlite import DataFile, MapTile
 from osm_fieldwork.xlsforms import xlsforms_path
 from osm_fieldwork.yamlfile import YamlFile
+
+from io import BytesIO  # Used for handling in-memory GeoJSON
+import json  # Used for parsing GeoJSON strings
 
 log = logging.getLogger(__name__)
 
@@ -125,7 +131,7 @@ class BaseMapper(object):
 
     def __init__(
         self,
-        boundary: str,
+        boundary: Union[str, bytes],  # Modify the type hint for boundary to accept bytes
         base: str,
         source: str,
         xy: bool,
@@ -153,6 +159,11 @@ class BaseMapper(object):
         path = xlsforms_path.replace("xlsforms", "imagery.yaml")
         self.yaml = YamlFile(path)
 
+        if isinstance(boundary, bytes):
+            self.bbox = self.makeBboxFromBytes(boundary)
+        else:
+            self.bbox = self.makeBbox(boundary)
+
         for entry in self.yaml.yaml["sources"]:
             for k, v in entry.items():
                 src = dict()
@@ -162,6 +173,98 @@ class BaseMapper(object):
                         # print(f"\tFIXME2: {k1} - {v1}")
                         src[k1] = v1
                 self.sources[k] = src
+
+    def makeBboxFromBytes(self, boundary_bytes: bytes) -> Tuple[float, float, float, float]:
+        """Make a bounding box from an in-memory GeoJSON (bytes).
+        Calculate the bounding box from GeoJSON data given in bytes.
+        This function takes GeoJSON data in bytes format and finds 
+        the corners of a rectangle that surrounds the map area described by the data.
+        The bounding box defines the rectangular area enclosing the 
+        spatial extent of the provided GeoJSON geometry or dataset.
+
+        Args:
+            boundary_bytes (bytes): GeoJSON data in bytes format. 
+            It represents the geographic features or geometries.
+
+        Returns:
+            Tuple[float, float, float, float]: A set of four numbers that tell you the corners of the rectangle surrounding the map area.
+            The numbers represent the left, bottom, right, and top edges of the rectangle, respectively.
+
+        Raises:
+            ValueError: If the GeoJSON data cannot be understood or does not contain valid map information.
+        """
+        try:
+            geojson_data = json.loads(boundary_bytes.decode("utf-8"))
+            geometry = shape(geojson_data["features"][0]["geometry"])
+
+            if isinstance(geometry, list):
+                # Multiple geometries
+                geometry = unary_union(geometry)
+
+            if geometry.is_empty:
+                raise ValueError("No bbox extracted from geometry")
+
+            bbox = geometry.bounds
+            return bbox
+        except Exception as e:
+            raise ValueError("Failed to parse in-memory GeoJSON.") from e
+
+    def makeBbox(self, boundary: Union[str, BytesIO]) -> Tuple[float, float, float, float]:
+        """
+        Make a bounding box from a shapely geometry, BBOX string, or GeoJSON bytes object.
+            This function calculates the corners of a rectangle that surrounds a piece of map data.
+            You can give it different types of map data:
+
+            - A string that says where the edges of the map are.
+            - A file that holds a map you've already made in a special format.
+
+            Args:
+                boundary (Union[str, BytesIO]): This is the information you're giving the 
+                function so it knows what map area you're talking about.
+                It could be:
+                - Something you drew on the map.
+                - A written-down description of the map's edges.
+                - A file that holds a map you've already made.
+
+            Returns:
+            tuple[float, float, float, float]: This tells you the corners 
+            of the rectangle that surrounds the map area.
+            The corners are given in the order: (left edge, bottom edge, right edge, top edge).
+        """
+        if isinstance(boundary, bytes):
+            return self.makeBboxFromBytes(boundary)
+        elif not isinstance(boundary, BytesIO):
+            # Assume it's a BBOX string
+            try:
+                if "," in boundary:
+                    bbox_parts = boundary.split(",")
+                else:
+                    bbox_parts = boundary.split(" ")
+                bbox = tuple(float(x) for x in bbox_parts)
+
+                if len(bbox) != 4:
+                    raise ValueError(f"BBOX string malformed: {bbox}")
+
+                return bbox
+            except Exception as e:
+                raise ValueError(f"Failed to parse BBOX string: {boundary}") from e
+        else:
+            # It's a GeoJSON bytes object or file path
+            try:
+                geojson_data = geojson.load(boundary)
+                geometry = shape(geojson_data["features"][0]["geometry"])
+
+                if isinstance(geometry, list):
+                    # Multiple geometries
+                    geometry = unary_union(geometry)
+
+                if geometry.is_empty:
+                    raise ValueError("No bbox extracted from geometry")
+
+                bbox = geometry.bounds
+                return bbox
+            except Exception as e:
+                raise ValueError(f"Failed to process GeoJSON: {boundary}") from e
 
     def customTMS(self, url: str, name: str = "custom", source: str = "custom", suffix: str = "jpg"):
         """Add a custom TMS URL to the list of sources.

--- a/osm_fieldwork/outreachy.py
+++ b/osm_fieldwork/outreachy.py
@@ -1,0 +1,9 @@
+from osm_fieldwork.basemapper import create_basemap_file
+
+create_basemap_file(
+    verbose=True,
+    boundary="-4.730494,41.650541,-4.725634,41.652874",
+    outfile="outreachy.mbtiles",
+    zooms="12-15",
+    source="esri",
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ ui = [
 
 [tool.black]
 line-length = 132
-target-versions = ["py310", "py311"]
+target-version = ["py310", "py311"]
 
 [tool.ruff]
 fix = true


### PR DESCRIPTION
…or boundary param


The two added functions to Basemapper class help figure out the edges of a map area based on different types of map information. Here's a simple breakdown of what they do:

**makeBboxFromBytes:**

Purpose: To find the edges of a map area from map data stored as bytes (like a file that's not saved on your computer but loaded in memory).
How it works: It takes the map data in bytes, reads it to understand the map's shape, and figures out the farthest points in all directions. These points make up a rectangle that completely covers the map area.

**makeBbox:**

Purpose: To find the map area's edges, but this time it can work with different types of input: a description as text, a file loaded in memory, or bytes.
How it works: Depending on what type of map information you give it, it either:
Directly uses the text to figure out the edges.
Loads the map from a file or bytes and then finds the edges in the same way as the first function.

**Added testcases which will test the the code:**

1. test_create_basemap_valid_parameters: Checks if a map file is correctly made when given the right settings.
2. test_create_basemap_invalid_parameters: Makes sure an error pops up if trying to make a map with the wrong settings.
3. test_custom_tms: Confirms that when you set up a custom map tile service, it's correctly saved and used.
4. test_pmtiles_generation: Verifies that a special map tile file (pmtiles) can be created and exists where it should.

Working on two more testcases but would need help in solving some of the errors. I would mean a lot if you would help me solve them :)