### PR TITLE
solves #204

### DIFF
--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -23,7 +23,9 @@ import logging
 import os
 import shutil
 
-from osm_fieldwork.basemapper import BaseMapper
+import pytest
+
+from osm_fieldwork.basemapper import BaseMapper, create_basemap_file
 from osm_fieldwork.sqlite import DataFile
 
 log = logging.getLogger(__name__)
@@ -31,19 +33,110 @@ log = logging.getLogger(__name__)
 rootdir = os.path.dirname(os.path.abspath(__file__))
 boundary = f"{rootdir}/testdata/Rollinsville.geojson"
 outfile = f"{rootdir}/testdata/rollinsville.mbtiles"
+tms_url = "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
+zooms = "10-12"
 base = "./tiles"
-# boundary = open(infile, "r")
-# poly = geojson.load(boundary)
-# if "features" in poly:
-#    geometry = shape(poly["features"][0]["geometry"])
-# elif "geometry" in poly:
-#    geometry = shape(poly["geometry"])
-# else:
-#    geometry = shape(poly)
+
+
+def test_create_basemap_valid_parameters():
+
+    """Test the creation of a basemap with valid parameters.
+
+    This test function verifies that a basemap can be created
+    successfully with valid parameters.
+    It calls the create_basemap_file function with valid boundary,
+    output file, zoom levels, and source information. It then checks
+    whether the output file exists after the basemap creation.
+    """
+    create_basemap_file(
+        boundary=boundary,
+        outfile=outfile,
+        zooms=zooms,
+        outdir=None,
+        source="esri",
+    )
+    assert os.path.exists(outfile)
+
+
+def test_create_basemap_invalid_parameters():
+
+    """Test the creation of a basemap with invalid parameters.
+
+    This test function ensures that creating a basemap with
+    invalid parameters raises a ValueError.
+    It calls the create_basemap_file function with invalid
+    boundary and output file valuesand checks whether a ValueError
+    is raised.
+    """
+    with pytest.raises(ValueError):
+        create_basemap_file(
+            boundary=None,
+            outfile=None,
+            zooms=zooms,
+            outdir=None,
+            source="esri",
+        )
+
+
+def test_custom_tms():
+
+    """Test custom tile mapping service.
+
+    This test function checks the functionality
+    of custom tile mapping service (TMS).
+    It creates an instance of BaseMapper and
+    sets a custom TMS URL. Then it verifies
+    that the custom TMS URL is correctly set in the sources dictionary.
+    """
+    basemap = BaseMapper(boundary, base=None, source="esri", xy=False)
+    tms_url = "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
+    basemap.customTMS(tms_url)
+    expected_url = "https://a.tile.openstreetmap.org/%s"
+    assert basemap.sources["custom"]["url"] == expected_url
+
+
+def test_pmtiles_generation():
+
+    """Test the generation of pmtiles.
+
+    This test function validates the generation of
+    pmtiles (Portable Map Tiles).
+    It calls the create_basemap_file function to
+    generate pmtiles with specified boundary,
+    output file, zoom levels, and source information.
+    Then it checks whether the output file exists.
+    """
+    create_basemap_file(
+        boundary=boundary,
+        outfile=outfile,
+        zooms=zooms,
+        outdir=None,
+        source="esri",
+    )
+    assert os.path.exists(outfile)
+
+
+# def test_boundary_parsing():
+#     expected_bbox = (-105.505833, 39.920833, -105.585833, 39.920574)
+#     basemap = BaseMapper(boundary, base=None, source="esri", xy=False)
+#     assert basemap.bbox == expected_bbox
+
+# def test_tile_id_generation():
+#     from osm_fieldwork.basemapper import tileid_from_y_tile
+#     tile_path = "esritiles/12/1525/1994.jpg"
+#     tile_id = tileid_from_y_tile(tile_path)
+#     assert tile_id == (12, 1525, 1994)
 
 
 def test_create():
-    """See if the file got loaded."""
+    """See if the file got loaded.
+
+    This test function ensures that a file is
+    successfully loaded and processed.
+    It creates an instance of BaseMapper,
+    retrieves tiles at specified zoom levels,
+    and writes the tiles to an output file.
+    """
     hits = 0
     basemap = BaseMapper(boundary, base, "topo", False)
     tiles = list()
@@ -68,3 +161,4 @@ def test_create():
 
 if __name__ == "__main__":
     test_create()
+    pytest.main()


### PR DESCRIPTION
Added two functions which help figure out the edges of a map area based on different types of map information. Here's a simple breakdown of what they do:

makeBboxFromBytes:
Finds the edges of a map area from map data stored as bytes (like a file that's not saved on your computer but loaded in memory).
Takes the map data in bytes, reads it to understand the map's shape, and figures out the farthest points in all directions.
The function returns the rectangle's edges as numbers (left, bottom, right, top).
If it can't understand the map data or if the data doesn't describe any area, it lets you know there's an issue.

makeBbox:
Finds the map area's edges, but this time it can work with different types of input: a description as text, a file loaded in memory, or bytes.
Depending on what type of map information you give it, it either:
Directly uses the text to figure out the edges.
Loads the map from a file or bytes and then finds the edges in the same way as the first function.
Like the first function, it returns the rectangle's edges that contain the map area.
It reports back if it can't understand the map information or if there's no clear map area described.

Added 4 testcases to assess my code, the description of each test case is as follows:
test_create_basemap_valid_parameters: Checks if a map file is correctly made when given the right settings.

test_create_basemap_invalid_parameters: Makes sure an error pops up if trying to make a map with the wrong settings.

test_custom_tms: Confirms that when you set up a custom map tile service, it's correctly saved and used.

test_pmtiles_generation: Verifies that a special map tile file (pmtiles) can be created and exists where it should.